### PR TITLE
add jQuery function to hide #box on .btn click

### DIFF
--- a/atv07/07.txt
+++ b/atv07/07.txt
@@ -1,0 +1,5 @@
+$(document).ready(function() {
+    $('.btn').on('click', function() {
+        $('#box').hide();
+    });
+});


### PR DESCRIPTION
Implements a jQuery script that hides the element with the ID box when any element with the class btn is clicked. The functionality includes:

Ensuring the DOM is fully loaded using $(document).ready().
Attaching a click event listener to elements with the class btn.
Using the jQuery .hide() method to hide the element with the ID box.
This script is a simple demonstration of DOM manipulation and event handling using jQuery.